### PR TITLE
Exception when sending current_url on v1/open in iframe

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -1043,7 +1043,13 @@ utils.getInitialReferrer = function(referringLink) {
 };
 
 utils.getCurrentUrl = function() {
-	return window.top.location.href || "";
+	if (utils.isIframeAndFromSameOrigin()) {
+		return window.top.location.href || "";
+	} else if (utils.isIframe) {
+		return "";
+	} else {
+		return window.location.href || "";
+	}
 };
 
 // Required for logEvent()'s custom_data object - values must be converted to string


### PR DESCRIPTION
- Fix Same Origin Policy restriction issue

There is exception when init branch.io in iframe 
```
Uncaught DOMException: Blocked a frame with origin "example.com" from accessing a cross-origin frame.
```