### PR TITLE
fix for alternate_browser_fingerprint_id encoding

### DIFF
--- a/src/2_session.js
+++ b/src/2_session.js
@@ -56,10 +56,12 @@ session.update = function(storage, newData) {
  * @param {Object} data 
  */
 function encodeBFPs(data) {
-	if (data && !utils.isBase64Encoded(data["browser_fingerprint_id"])) {
+	if (data && data["browser_fingerprint_id"] 
+		&& !utils.isBase64Encoded(data["browser_fingerprint_id"])) {
 		data["browser_fingerprint_id"] = btoa(data["browser_fingerprint_id"]);
 	}
-	if (data && !utils.isBase64Encoded(data["alternative_browser_fingerprint_id"])) {
+	if (data && data["alternative_browser_fingerprint_id"]
+		&& !utils.isBase64Encoded(data["alternative_browser_fingerprint_id"])) {
 		data["alternative_browser_fingerprint_id"] = btoa(data["alternative_browser_fingerprint_id"]);
 	}
 	return data;
@@ -74,8 +76,8 @@ function decodeBFPs(data) {
 	if (data && utils.isBase64Encoded(data["browser_fingerprint_id"])) {
 		data["browser_fingerprint_id"] = atob(data["browser_fingerprint_id"]);
 	}
-	if (data && utils.isBase64Encoded(data["browser_fingerprint_id"])) {
-		data["browser_fingerprint_id"] = atob(data["browser_fingerprint_id"]);
+	if (data && utils.isBase64Encoded(data["alternative_browser_fingerprint_id"])) {
+		data["alternative_browser_fingerprint_id"] = atob(data["alternative_browser_fingerprint_id"]);
 	}
 	return data;
 }


### PR DESCRIPTION
The issue was that when alternative_browser_fingerprint_id is set to undefined - it gets encoded. Previously it would just be undefined, but now "undefined" would just get encoded, which caused the issue. 