### PR TITLE
Fix lint errors and use vanilla JS

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -233,7 +233,7 @@ utils.message = function(message, params, failCode, failDetails) {
  * @param {Object} data
  * @return {utils.sessionData}
  */
-utils.whiteListSessionData = function(data) {	
+utils.whiteListSessionData = function(data) {
 	return {
 		'data': data['data'] || "",
 		'data_parsed': data['data_parsed'] || {},
@@ -615,45 +615,50 @@ utils.base64Decode = function(str) {
 		return atob(str);
 	}
 	return str;
-}
+};
 
 /**
  * Check if a String is a BASE64 encoded value
- * @param {string} str 
+ * @param {string} str
  */
 utils.isBase64Encoded = function(str) {
-	if (typeof str != "string") { return false; }
-	if (str ==='' || str.trim() ==='') { return false; }
-    try {
-        return btoa(atob(str)) === str;
-    } catch (err) {
-        return false;
-    }
-} 
+	if (typeof str !== "string") {
+		return false;
+	}
+	if (str === '' || str.trim() === '') {
+		return false;
+	}
+	try {
+		return btoa(atob(str)) === str;
+	}
+	catch (err) {
+		return false;
+	}
+};
 
 /**
  * Encodes BFP in data object with Base64 encoding.
  * BFP is supposed to be Base64 encoded when stored in local storage/cookie.
- * @param {Object} data 
+ * @param {Object} data
  */
 utils.encodeBFPs = function(data) {
-	if (data && data["browser_fingerprint_id"]
-		&& !utils.isBase64Encoded(data["browser_fingerprint_id"])) {
+	if (data && data["browser_fingerprint_id"] &&
+		!utils.isBase64Encoded(data["browser_fingerprint_id"])) {
 		data["browser_fingerprint_id"] = btoa(data["browser_fingerprint_id"]);
 	}
-	if (data && data["alternative_browser_fingerprint_id"]
-		&& !utils.isBase64Encoded(data["alternative_browser_fingerprint_id"])) {
+	if (data && data["alternative_browser_fingerprint_id"] &&
+		!utils.isBase64Encoded(data["alternative_browser_fingerprint_id"])) {
 		data["alternative_browser_fingerprint_id"] = btoa(data["alternative_browser_fingerprint_id"]);
 	}
 	return data;
-}
+};
 
 /**
  * Decodes BFPs in data object from Base64 encoding.
  * BFP is supposed to be Base64 encoded when stored in local storage/cookie.
  * @param {Object} data
  */
-utils.decodeBFPs = function (data) {
+utils.decodeBFPs = function(data) {
 	if (data && utils.isBase64Encoded(data["browser_fingerprint_id"])) {
 		data["browser_fingerprint_id"] = atob(data["browser_fingerprint_id"]);
 	}
@@ -661,7 +666,7 @@ utils.decodeBFPs = function (data) {
 		data["alternative_browser_fingerprint_id"] = atob(data["alternative_browser_fingerprint_id"]);
 	}
 	return data;
-}
+};
 
 /**
  * Add event listeners to elements, taking older browsers into account

--- a/src/2_session.js
+++ b/src/2_session.js
@@ -15,7 +15,7 @@ goog.require('storage');
 session.get = function(storage, first) {
 	var sessionString = first ? 'branch_session_first' : 'branch_session';
 	try {
-		let data = safejson.parse(storage.get(sessionString, first)) || null;
+		var data = safejson.parse(storage.get(sessionString, first)) || null;
 		return utils.decodeBFPs(data);
 	}
 	catch (e) {
@@ -55,17 +55,16 @@ session.update = function(storage, newData) {
  * @param {Object} data
  * @param {boolean=} druable
  */
-session.patch = function(storage, data, updateLocalStorage){
-
-	var merge = (source, patch) => {
+session.patch = function(storage, data, updateLocalStorage) {
+	var merge = function(source, patch) {
 		return utils.encodeBFPs(utils.merge(goog.json.parse(source), patch));
 	};
 
 	var session = storage.get('branch_session', false) || {};
 	storage.set('branch_session', goog.json.serialize(merge(session, data)));
 
-	if (updateLocalStorage){
-		const sessionFirst = storage.get('branch_session_first', true) || {};
+	if (updateLocalStorage) {
+		var sessionFirst = storage.get('branch_session_first', true) || {};
 		storage.set('branch_session_first', goog.json.serialize(merge(sessionFirst, data)), true);
 	}
 };

--- a/src/2_storage.js
+++ b/src/2_storage.js
@@ -102,10 +102,10 @@ var webStorage = function(perm) {
 		},
 		get: function(key, perm_override) {
 			// Make sure that browser_fingerprint_id gets decoded every time it is accessed.
-			if (key == 'browser_fingerprint_id' || key == "alternative_browser_fingerprint_id") {
+			if (key === 'browser_fingerprint_id' || key === "alternative_browser_fingerprint_id") {
 				return perm_override && localStorage ?
-				utils.base64Decode(localStorage.getItem(prefix(key))) :
-				utils.base64Decode(storageMethod.getItem(prefix(key)))
+					utils.base64Decode(localStorage.getItem(prefix(key))) :
+					utils.base64Decode(storageMethod.getItem(prefix(key)));
 			}
 			return retrieveValue(
 				perm_override && localStorage ?

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -152,7 +152,7 @@ Branch = function() {
  * @param {function(?Error,?)=} callback
  */
 Branch.prototype._api = function(resource, obj, callback) {
-	
+
 	if (this.app_id) {
 		obj['app_id'] = this.app_id;
 	}
@@ -170,13 +170,14 @@ Branch.prototype._api = function(resource, obj, callback) {
 		obj['identity_id'] = this.identity_id;
 	}
 
-	if (resource.endpoint.indexOf("/v1/") < 0){
+	if (resource.endpoint.indexOf("/v1/") < 0) {
 		if (((resource.params && resource.params['developer_identity']) ||
 			(resource.queryPart && resource.queryPart['developer_identity'])) &&
 			this.identity) {
-	   		obj['developer_identity'] = this.identity;
+			obj['developer_identity'] = this.identity;
 		}
-	}else{
+	}
+	else {
 		if (((resource.params && resource.params['identity']) ||
 			(resource.queryPart && resource.queryPart['identity'])) &&
 			this.identity) {
@@ -369,7 +370,7 @@ Branch.prototype['init'] = wrap(
 		};
 
 		var sessionData = session.get(self._storage);
-	
+
 		var branchMatchIdFromOptions = (options && typeof options['branch_match_id'] !== 'undefined' && options['branch_match_id'] !== null) ?
 			options['branch_match_id'] :
 			null;
@@ -377,7 +378,6 @@ Branch.prototype['init'] = wrap(
 		var freshInstall = !sessionData || !sessionData['identity_id'];
 		self._branchViewEnabled = !!self._storage.get('branch_view_enabled');
 		var checkHasApp = function(cb) {
-			
 			var params_r = { "sdk": config.version, "branch_key": self.branch_key };
 			var currentSessionData = session.get(self._storage) || {};
 			var permData = session.get(self._storage, true) || {};
@@ -421,18 +421,18 @@ Branch.prototype['init'] = wrap(
 		};
 
 		var restoreIdentityOnInstall = function(data) {
-			if(freshInstall){
-				data["identity"] = self.identity;  
+			if (freshInstall) {
+				data["identity"] = self.identity;
 			}
 			return data;
-		}
+		};
 
 		var finishInit = function(err, data) {
 
 			if (data) {
-				data = setBranchValues(data);			
+				data = setBranchValues(data);
 
-				if (!utils.userPreferences.trackingDisabled) {					
+				if (!utils.userPreferences.trackingDisabled) {
 					data = restoreIdentityOnInstall(data);
 					session.set(self._storage, data, freshInstall);
 				}
@@ -589,14 +589,14 @@ Branch.prototype['init'] = wrap(
 							"initial_referrer": utils.getInitialReferrer(self._referringLink()),
 							"current_url": utils.getCurrentUrl(),
 							"screen_height": utils.getScreenHeight(),
-							"screen_width": utils.getScreenWidth()							
+							"screen_width": utils.getScreenWidth()
 						},
 						function(err, data) {
 							if (err) {
 								self.init_state_fail_code = init_state_fail_codes.OPEN_FAILED;
 								self.init_state_fail_details = err.message;
 							}
-							if (!err && typeof data === 'object') {						
+							if (!err && typeof data === 'object') {
 								if (data['branch_view_enabled']) {
 									self._branchViewEnabled = !!data['branch_view_enabled'];
 									self._storage.set('branch_view_enabled', self._branchViewEnabled);
@@ -772,16 +772,16 @@ Branch.prototype['setIdentity'] = wrap(callback_params.CALLBACK_ERR_DATA, functi
 
 			data = data || { };
 			self.identity_id = data['identity_id'] ? data['identity_id'].toString() : null;
-			self.sessionLink = data['link'];			
+			self.sessionLink = data['link'];
 
 			self.identity = identity;
-			data['developer_identity'] = identity;	
+			data['developer_identity'] = identity;
 
 			data['referring_data_parsed'] = data['referring_data'] ?
 				safejson.parse(data['referring_data']) :
 				null;
 
-			session.patch(self._storage, {"identity": identity}, true);
+			session.patch(self._storage, { "identity": identity }, true);
 			done(null, data);
 		}
 	);
@@ -824,7 +824,7 @@ Branch.prototype['logout'] = wrap(callback_params.CALLBACK_ERR, function(done) {
 			"referring_link": null,
 			"click_id": null,
 			"link_click_id": null,
-			"identity": data['identity'],		
+			"identity": data['identity'],
 			"session_id": data['session_id'],
 			"identity_id": data['identity_id'],
 			"link": data['link'],


### PR DESCRIPTION
cc @BranchMetrics/core-team 

I am fixing a bunch of lint errors and also moving some code back to old pre-ES6 rules. @rubinsingh and I aren't sure if we can safely move to ES6 yet, but I am opting to just push back to old vanilla JS for now to limit risk.