### PR TITLE
Has app fix falsify

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -237,7 +237,7 @@ utils.whiteListSessionData = function(data) {
 	return {
 		'data': data['data'] || "",
 		'data_parsed': data['data_parsed'] || {},
-		'has_app': data['has_app'] || null,
+		'has_app': utils.getBooleanOrNull(data['has_app']),
 		'identity': data['developer_identity'] || null,
 		'developer_identity': data['developer_identity'] || null,
 		'referring_identity': data['referring_identity'] || null,
@@ -1164,3 +1164,10 @@ utils.addNonceAttribute = function(element) {
 	}
 };
 
+utils.getBooleanOrNull = function (value) {
+	if (value === undefined) {
+		return null;
+	}
+
+	return value;
+};

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -1164,7 +1164,7 @@ utils.addNonceAttribute = function(element) {
 	}
 };
 
-utils.getBooleanOrNull = function (value) {
+utils.getBooleanOrNull = function(value) {
 	if (value === undefined) {
 		return null;
 	}


### PR DESCRIPTION
After we have initialized the SDK with `branch.init()` get in the callback the field **data**. This field contains among others **has_app**.  If there are no apps the value should be **false**. But in any case of **false** we got **null** as result. 

Solution:

The condition: `data['has_app'] || null,` gets always null or true, because we have falsified here. 
Se solution contains now a new function witch checks this case and provides the functionality to the SDK 
