### PR TITLE
[APPSEC-264] Escape SDK output to prevent XSS

### DIFF
--- a/example.html
+++ b/example.html
@@ -116,26 +116,13 @@
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData".split(" "), 0);
 
-		// https://stackoverflow.com/a/6234804/875725
-		function escapeHtml(unsafe) {
-		    return unsafe
-		         .replace(/&/g, "&amp;")
-		         .replace(/</g, "&lt;")
-		         .replace(/>/g, "&gt;")
-		         .replace(/"/g, "&quot;")
-		         .replace(/'/g, "&#039;");
-		}
-
 		// Note that this example is using the key in two places, here and below
 		branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {
 			// Escape any HTML in the output to avoid XSS.
-			document.getElementsByClassName('info')[0].innerHTML = escapeHtml(JSON.stringify(data));
+			$('.info').text(JSON.stringify(data));
 		});
 	</script>
 	<script type="text/javascript">
-		var info = $('.info');
-		var request = $('.request');
-		var response = $('.response');
 		var sampleParams = {
 			tags: [ 'tag1', 'tag2' ],
 			channel: 'sample app',

--- a/example.html
+++ b/example.html
@@ -35,13 +35,13 @@
 		<section>
 			<div class="row col-lg-8 col-lg-offset-2">
 				<h4>Session Info</h4>
-				<pre class="info">Reading session from .init()...</pre>
+				<pre id="info">Reading session from .init()...</pre>
 				<br>
 				<h4>Request</h4>
-				<pre class="request">Click a button!</pre>
+				<pre id="request">Click a button!</pre>
 				<br>
 				<h4>Response</h4>
-				<pre class="response">Click a button!</pre>
+				<pre id="response">Click a button!</pre>
 			</div>
 		</section>
 		<section>
@@ -119,10 +119,12 @@
 		// Note that this example is using the key in two places, here and below
 		branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {
 			// Escape any HTML in the output to avoid XSS.
-			$('.info').text(JSON.stringify(data));
+			$('#info').text(JSON.stringify(data));
 		});
 	</script>
 	<script type="text/javascript">
+	  var request = $('#request');
+		var response = $('#response');
 		var sampleParams = {
 			tags: [ 'tag1', 'tag2' ],
 			channel: 'sample app',

--- a/example.html
+++ b/example.html
@@ -116,9 +116,20 @@
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData".split(" "), 0);
 
+		// https://stackoverflow.com/a/6234804/875725
+		function escapeHtml(unsafe) {
+		    return unsafe
+		         .replace(/&/g, "&amp;")
+		         .replace(/</g, "&lt;")
+		         .replace(/>/g, "&gt;")
+		         .replace(/"/g, "&quot;")
+		         .replace(/'/g, "&#039;");
+		}
+
 		// Note that this example is using the key in two places, here and below
 		branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {
-			document.getElementsByClassName('info')[0].innerHTML = JSON.stringify(data);
+			// Escape any HTML in the output to avoid XSS.
+			document.getElementsByClassName('info')[0].innerHTML = escapeHtml(JSON.stringify(data));
 		});
 	</script>
 	<script type="text/javascript">


### PR DESCRIPTION
Escape HTML output from SDK open response before rendering to avoid XSS.

~~There doesn't seem to be a standard API for HTML escaping, at least from a quick search. It is undoubtedly also possible to do this with jQuery or bootstrap, which are both used in this example.~~ The [jQuery .text() method](https://api.jquery.com/text/#text2) makes this a one-liner.

~~I also need to find a way to test this, since it requires following a link. I think I can just hack my local copy of the SDK to open a malicious link on load.~~ I've verified this by adding HTML to the output, e.g.:

```js
			$('.info').text('<p>' + JSON.stringify(data) + '</p>');
```

Appreciate any feedback.