### PR TITLE
[INTENG-9975] Add support for a _web_open_delay_ms query param

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -1179,3 +1179,19 @@ utils.getBooleanOrNull = function(value) {
 
 	return value;
 };
+
+/**
+ * Execute operation immediately or after a timeout.
+ * setTimeout(operation, 0) will enqueue the operation and may not execute
+ * right away.
+ * @param {function} operation A function with no arguments to be executed after delay ms.
+ * @param {number} delay Operation will be executed after this number of ms. If 0, the operation is executed immediately, not using setTimeout.
+ */
+utils.delay = function(operation, delay) {
+	if (isNaN(delay) || delay <= 0) {
+		operation();
+		return;
+	}
+
+	setTimeout(operation, delay);
+};

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -569,8 +569,8 @@ Branch.prototype['init'] = wrap(
 			self.identity = permData['identity'];
 		}
 
-		// Execute the /v1/open right away or after _web_open_delay_ms.
-		var open_delay = parseInt(utils.getParamValue('_web_open_delay_ms'), 10);
+		// Execute the /v1/open right away or after _open_delay_ms.
+		var open_delay = parseInt(utils.getParamValue('[?&]_open_delay_ms'), 10);
 
 		if (!utils.isSafari11OrGreater()) {
 			self._api(
@@ -618,36 +618,38 @@ Branch.prototype['init'] = wrap(
 			);
 		}
 		else {
-			self._api(
-				resources.open,
-				{
-					"link_identifier": link_identifier,
-					"browser_fingerprint_id": link_identifier || permData['browser_fingerprint_id'],
-					"alternative_browser_fingerprint_id": permData['browser_fingerprint_id'],
-					"options": options,
-					"initial_referrer": utils.getInitialReferrer(self._referringLink()),
-					"current_url": utils.getCurrentUrl(),
-					"screen_height": utils.getScreenHeight(),
-					"screen_width": utils.getScreenWidth()
-				},
-				function(err, data) {
-					if (err) {
-						self.init_state_fail_code = init_state_fail_codes.OPEN_FAILED;
-						self.init_state_fail_details = err.message;
-					}
-					if (!err && typeof data === 'object') {
-						if (data['branch_view_enabled']) {
-							self._branchViewEnabled = !!data['branch_view_enabled'];
-							self._storage.set('branch_view_enabled', self._branchViewEnabled);
+			utils.delay(function() {
+				self._api(
+					resources.open,
+					{
+						"link_identifier": link_identifier,
+						"browser_fingerprint_id": link_identifier || permData['browser_fingerprint_id'],
+						"alternative_browser_fingerprint_id": permData['browser_fingerprint_id'],
+						"options": options,
+						"initial_referrer": utils.getInitialReferrer(self._referringLink()),
+						"current_url": utils.getCurrentUrl(),
+						"screen_height": utils.getScreenHeight(),
+						"screen_width": utils.getScreenWidth()
+					},
+					function(err, data) {
+						if (err) {
+							self.init_state_fail_code = init_state_fail_codes.OPEN_FAILED;
+							self.init_state_fail_details = err.message;
 						}
-						if (link_identifier) {
-							data['click_id'] = link_identifier;
+						if (!err && typeof data === 'object') {
+							if (data['branch_view_enabled']) {
+								self._branchViewEnabled = !!data['branch_view_enabled'];
+								self._storage.set('branch_view_enabled', self._branchViewEnabled);
+							}
+							if (link_identifier) {
+								data['click_id'] = link_identifier;
+							}
 						}
+						attachVisibilityEvent();
+						finishInit(err, data);
 					}
-					attachVisibilityEvent();
-					finishInit(err, data);
-				}
-			);
+				);
+			}, open_delay);
 		}
 	},
 	true


### PR DESCRIPTION
See also https://github.com/BranchMetrics/branch-backend/pull/5849. Together these allow for a `$desktop_web_open_delay_ms` key that can be used to delay the POST to `/v1/open` from `branch.init()` when opening in a browser on the web. This can help alleviate a race condition with desktop apps.