### PR TITLE
Update examples

### DIFF
--- a/event-v2-example.html
+++ b/event-v2-example.html
@@ -77,15 +77,16 @@
 		console.log('Initializing with branch_key=' + JSON.stringify(branch_key));
 		$('#request').text('branch.init(' + JSON.stringify(branch_key) + ', function(err, data) {...})');
 		branch.init(branch_key, function(err, data) {
-			$('#response').text(JSON.stringify(data));
 
 			// using jQuery .text() here avoids XSS in case this is ever hosted.
 			if (err) {
 				$('#info').text(JSON.stringify(err));
+				$('#response').text(JSON.stringify(err));
 				return;
 			}
 
 			$('#info').text(JSON.stringify(data));
+			$('#response').text(JSON.stringify(data));
 			$('.btn').removeAttr('disabled');
 		});
 	</script>

--- a/event-v2-example.html
+++ b/event-v2-example.html
@@ -60,11 +60,25 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 	<script type="text/javascript">
-		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode banner closeBanner creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setIdentity track validateCode".split(" "), 0);
+		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback".split(" "), 0);
+
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
+			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			if (error) {
+				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+			else {
+				console.log('Response: status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+		});
 
 		// Take Branch key from meta tag.
 		var branch_key = $('meta[name="branch_key"]').attr('content');
+		console.log('Initializing with branch_key=' + JSON.stringify(branch_key));
+		$('#request').text('branch.init(' + JSON.stringify(branch_key) + ', function(err, data) {...})');
 		branch.init(branch_key, function(err, data) {
+			$('#response').text(JSON.stringify(data));
+
 			// using jQuery .text() here avoids XSS in case this is ever hosted.
 			if (err) {
 				$('#info').text(JSON.stringify(err));

--- a/example-deepview.html
+++ b/example-deepview.html
@@ -58,7 +58,17 @@
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 	<script type="text/javascript">
 
-		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode banner closeBanner creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setIdentity track validateCode".split(" "), 0);
+		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback".split(" "), 0);
+
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
+			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			if (error) {
+				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+			else {
+				console.log('Response: status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+		});
 
 		// Note that this example is using the key in two places, here and below
 		branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {

--- a/src/web/example.template.html
+++ b/src/web/example.template.html
@@ -116,6 +116,16 @@
 	<script type="text/javascript">
 		// INSERT INIT CODE
 
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
+			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			if (error) {
+				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+			else {
+				console.log('Response: status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
+			}
+		});
+
 		// Note that this example is using the key in two places, here and below
 		branch.init('key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv', function(err, data) {
 			// Avoid XSS by HTML escaping the data for display


### PR DESCRIPTION
Relevant to INTENG-10487 as an example of usage.

This updates the JS snippet that imports the API to include newly-added methods. The main `example.html` is generated from a template. The new methods have all been added to `onpage.js` already.

This adds API logging to all examples via `branch.setAPIResponseCallback`. It also updates `event-v2-example.html`. I was getting errors, so added some additional output. The `example-deepview.html` and `event-v2-example.html` are not deployed. Also updated the template for the main `example.html`.

This is a nice thing to have, since console logging is always available even after the fact. If you open a page without the developer console open, you can't see previous network traffic, but you can see previous logging. Also this records only traffic to and from the Branch API.