### PR TITLE
Comment out broken/unused slack notification

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -139,7 +139,7 @@ EOF
   # #uncomment to send updates to int-eng
   # #slackcli -t $SLACK_TOKEN -h int-eng -m $MESSAGE -u websdk-deploy -i $DEPLOY_IMG
   # slackcli -t $SLACK_TOKEN -h web-sdk -m "$CIRCLE_USERNAME deployed WebSDK v$VERSION" -u websdk-deploy -i $DEPLOY_IMG
-	#
+  #
   # echo "Please update the javascript version in https://github.com/BranchMetrics/documentation/edit/master/ingredients/web_sdk/_initialization.md"
 
   echo "Check the following links are valid:"

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -133,13 +133,14 @@ EOF
 
   # Send an update to slack channels
 
-  DEPLOY_IMG=http://workshops.lewagon.org/assets/landing-2/deploy-button-5068ec2c575492ba428569111afe3ce6.jpg
-  echo -en "${GREEN}Sending update to slack ...${NC}\n"
-  #uncomment to send updates to int-eng
-  #slackcli -t $SLACK_TOKEN -h int-eng -m $MESSAGE -u websdk-deploy -i $DEPLOY_IMG
-  slackcli -t $SLACK_TOKEN -h web-sdk -m "$CIRCLE_USERNAME deployed WebSDK v$VERSION" -u websdk-deploy -i $DEPLOY_IMG
-
-  echo "Please update the javascript version in https://github.com/BranchMetrics/documentation/edit/master/ingredients/web_sdk/_initialization.md"
+  # Currently broken. Was sending to archived #web-sdk channel anyway.
+  # DEPLOY_IMG=http://workshops.lewagon.org/assets/landing-2/deploy-button-5068ec2c575492ba428569111afe3ce6.jpg
+  # echo -en "${GREEN}Sending update to slack ...${NC}\n"
+  # #uncomment to send updates to int-eng
+  # #slackcli -t $SLACK_TOKEN -h int-eng -m $MESSAGE -u websdk-deploy -i $DEPLOY_IMG
+  # slackcli -t $SLACK_TOKEN -h web-sdk -m "$CIRCLE_USERNAME deployed WebSDK v$VERSION" -u websdk-deploy -i $DEPLOY_IMG
+	#
+  # echo "Please update the javascript version in https://github.com/BranchMetrics/documentation/edit/master/ingredients/web_sdk/_initialization.md"
 
   echo "Check the following links are valid:"
   echo "- https://cdn.branch.io/branch-$VERSION.min.js"


### PR DESCRIPTION
This was going to the archived #web-sdk channel anyway. It's the last thing that happens in the script, so failure is benign. We can restore this at need.