### PR TITLE
INTENG-11116: Fix unsafe eval error

### DIFF
--- a/src/2_session.js
+++ b/src/2_session.js
@@ -58,7 +58,7 @@ session.update = function(storage, newData) {
  */
 session.patch = function(storage, data, updateLocalStorage, removeNull) {
 	var merge = function(source, patch) {
-		return utils.encodeBFPs(utils.merge(goog.json.parse(source), patch, removeNull));
+		return utils.encodeBFPs(utils.merge(safejson.parse(source), patch, removeNull));
 	};
 
 	var session = storage.get('branch_session', false) || {};


### PR DESCRIPTION
Undoing usage of `goog.json.parse` and replacing with `safejson.parse` to prevent "'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive"

This was the original commit: https://github.com/BranchMetrics/web-branch-deep-linking-attribution/commit/35296af3d388779a75be748f3aa5b1684e313b5c#diff-d744691a59bf20af6d8cbb5a3dace22c