### PR TITLE
[CORE-1386] Report X-Branch-Request-Id header if present

### DIFF
--- a/event-v2-example.html
+++ b/event-v2-example.html
@@ -62,8 +62,13 @@
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback".split(" "), 0);
 
-		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
-			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody, requestId) {
+			if (requestId) {
+				console.log('Request [' + requestId + ']: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
+			else {
+				console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
 			if (error) {
 				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
 			}

--- a/example.html
+++ b/example.html
@@ -116,8 +116,13 @@
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="dist/build.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener applyCode autoAppIndex banner closeBanner closeJourney creditHistory credits data deepview deepviewCta first getCode init link logout redeem referrals removeListener sendSMS setBranchViewData setIdentity track validateCode trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback".split(" "), 0);
 
-		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
-			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody, requestId) {
+			if (requestId) {
+				console.log('Request [' + requestId + ']: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
+			else {
+				console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
 			if (error) {
 				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
 			}

--- a/src/3_api.js
+++ b/src/3_api.js
@@ -324,7 +324,7 @@ Server.prototype.XHRRequest = function(url, data, method, storage, callback, nop
 				// Server returns helpful information when a partner sends up incorrect fields in logEvent().
 				// This information appears in req.responseText.
 				if (req['responseURL'] && req['responseURL'].includes("v2/event")) {
-					callback(req['responseText'], null, req['status']);
+					callback(req['responseText'], null, req['status'], requestId);
 				}
 				else {
 					callback(new Error('Error in API: ' + req.status), null, req.status, requestId);

--- a/src/web/example.template.html
+++ b/src/web/example.template.html
@@ -116,8 +116,13 @@
 	<script type="text/javascript">
 		// INSERT INIT CODE
 
-		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
-			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody, requestId) {
+			if (requestId) {
+				console.log('Request [' + requestId + ']: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
+			else {
+				console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));
+			}
 			if (error) {
 				console.log('Response: Error ' + error + '; status ' + JSON.stringify(status) + ' body=' + JSON.stringify(responseBody));
 			}


### PR DESCRIPTION
In any XHR response (which excludes only the `/_r` and `/v1/deepview` endpoints), pass any `X-Branch-Request-Id` header back as a seventh argument in the argument to `branch.setAPIResponseCallback`. The example.html is generated from a template. Both the template and the generated example.html were updated, for convenience, as well as the event-v2-example.html, which is not generated and not deployed.

To test with this against a beta, change the domains in `src/0_config.js`, rebuild the SDK and then test with example.html or event-v2-example.html.