### PR TITLE
[INTENG-11098][CORE-1417] Identity fixes

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -239,7 +239,7 @@ utils.whiteListSessionData = function(data) {
 		'data_parsed': data['data_parsed'] || {},
 		'has_app': utils.getBooleanOrNull(data['has_app']),
 		'identity': data['identity'] || null,
-		'developer_identity': data['developer_identity'] || null,
+		'developer_identity': data['identity'] || null,
 		'referring_identity': data['referring_identity'] || null,
 		'referring_link': data['referring_link'] || null
 	};

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -238,7 +238,7 @@ utils.whiteListSessionData = function(data) {
 		'data': data['data'] || "",
 		'data_parsed': data['data_parsed'] || {},
 		'has_app': utils.getBooleanOrNull(data['has_app']),
-		'identity': data['developer_identity'] || null,
+		'identity': data['identity'] || null,
 		'developer_identity': data['developer_identity'] || null,
 		'referring_identity': data['referring_identity'] || null,
 		'referring_link': data['referring_link'] || null

--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -105,8 +105,7 @@ resources.open = {
 		"tracking_disabled": validator(false, validationTypes.BOOLEAN),
 		"current_url": validator(false, validationTypes.STRING),
 		"screen_height": validator(false, validationTypes.NUMBER),
-		"screen_width": validator(false, validationTypes.NUMBER),
-		"identity": validator(false, validationTypes.STRING)
+		"screen_width": validator(false, validationTypes.NUMBER)
 	}
 };
 

--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -371,7 +371,7 @@ resources.pageview = {
 		"journey_displayed": validator(false, validationTypes.BOOLEAN),
 		"audience_rule_id": validator(false, validationTypes.STRING),
 		"journey_dismissals": validator(false, validationTypes.OBJECT),
-		"identity": validator(false, validationTypes.STRING)
+		"identity_id": validator(false, validationTypes.STRING)
 	})
 };
 

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -341,6 +341,11 @@ Branch.prototype['init'] = wrap(
 			utils.cleanApplicationAndSessionStorage(self);
 		}
 
+		// initialize identity_id from storage
+		// note the previous line scrubs this if tracking disabled.
+		var localData = session.get(self._storage, /* use local if possible */ true);
+		self.identity_id = localData && localData['identity_id'];
+
 		var setBranchValues = function(data) {
 			if (data['link_click_id']) {
 				self.link_click_id = data['link_click_id'].toString();

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -343,7 +343,7 @@ Branch.prototype['init'] = wrap(
 
 		// initialize identity_id from storage
 		// note the previous line scrubs this if tracking disabled.
-		var localData = session.get(self._storage, /* use local if possible */ true);
+		var localData = session.get(self._storage, true);
 		self.identity_id = localData && localData['identity_id'];
 
 		var setBranchValues = function(data) {

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -788,7 +788,8 @@ Branch.prototype['setIdentity'] = wrap(callback_params.CALLBACK_ERR_DATA, functi
 				safejson.parse(data['referring_data']) :
 				null;
 
-			session.patch(self._storage, { "identity": identity }, true);
+			// /v1/profile will return a new identity_id, but the same session_id
+			session.patch(self._storage, { "identity": identity, "identity_id": self.identity_id }, true);
 			done(null, data);
 		}
 	);
@@ -838,6 +839,7 @@ Branch.prototype['logout'] = wrap(callback_params.CALLBACK_ERR, function(done) {
 			"device_fingerprint_id": self.device_fingerprint_id || null
 		};
 
+		// /v1/logout will return a new identity_id and a new session_id
 		self.sessionLink = data['link'];
 		self.session_id = data['session_id'];
 		self.identity_id = data['identity_id'];

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -380,7 +380,7 @@ Branch.prototype['init'] = wrap(
 			options['branch_match_id'] :
 			null;
 		var link_identifier = (branchMatchIdFromOptions || utils.getParamValue('_branch_match_id') || utils.hashValue('r'));
-		var freshInstall = !sessionData || !sessionData['identity_id'];
+		var freshInstall = !self.identity_id; // initialized from local storage above
 		self._branchViewEnabled = !!self._storage.get('branch_view_enabled');
 		var checkHasApp = function(cb) {
 			var params_r = { "sdk": config.version, "branch_key": self.branch_key };

--- a/src/web/example.template.html
+++ b/src/web/example.template.html
@@ -52,6 +52,7 @@
 				<div class="group">
 					<button id="init" class="btn btn-success">.init()</button>
 					<button id="data" class="btn btn-info">.data()</button>
+					<button id="first" class="btn btn-info">.first()</button>
 					<input class="example-input" type="text" id="identityID" class="form-control" placeholder="test@test.com">
 					<button id="setIdentity" class="btn btn-info">.setIdentity()</button>
 					<button id="logout" class="btn btn-info">.logout()</button>
@@ -170,6 +171,12 @@
 		$('#data').click(function() {
 			request.html('branch.data();');
 			branch.data(function(err, data) {
+				response.html(err || JSON.stringify(data));
+			});
+		});
+		$('#first').click(function() {
+			request.html('branch.first();');
+			branch.first(function(err, data) {
 				response.html(err || JSON.stringify(data));
 			});
 		});

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -58,9 +58,13 @@ describe('utils', function() {
 	describe('whiteListSessionData', function() {
 		it('should remove unwanted params', function() {
 			/*
-			 * This actually describes how whitelistSessionData works. It looks for
-			 * developer_identity in the input and outputs both identity and
-			 * developer_identity. Perhaps this is used as a filter elsewhere.
+			 * This is only used with responses to /v1/open, so there will never
+			 * be a developer_identity (or user_data.developer_identity), just
+			 * identity. As of 2.56.2, both params in every open response are null.
+			 * This has been changed so that each is mapped to itself in the
+			 * whitelisted response passed to the developer. Removing
+			 * developer_identity seems risky, but setting identity to the correct
+			 * value is an improvement over two nulls.
 			 */
 			var input = {
 				"data": "string",
@@ -68,6 +72,7 @@ describe('utils', function() {
 					"key": "value"
 				},
 				"has_app": true,
+				"identity": "90210",
 				"developer_identity": "67890",
 				"referring_identity": "12345",
 				"referring_link": null,
@@ -79,7 +84,7 @@ describe('utils', function() {
 					"key": "value"
 				},
 				"has_app": true,
-				"identity": "67890",
+				"identity": "90210",
 				"developer_identity": "67890",
 				"referring_identity": "12345",
 				"referring_link": null

--- a/test/3_api.js
+++ b/test/3_api.js
@@ -412,6 +412,25 @@ describe('Server', function() {
 				assert.strictEqual(requests.length, 0, 'No request made');
 			});
 
+			it ('should not include developer identity', function(done) {
+				var assert = testUtils.plan(1, done);
+				storage.set('use_jsonp', false);
+				storage.set('identity', '12345678');
+				server.request(
+					resources.open,
+					testUtils.params({}),
+					storage,
+					assert.done
+				);
+				var request = requests[0];
+				assert.ok(!request.requestBody.includes('identity='), 'Does not include identity');
+				requests[0].respond(
+					200,
+					{ "Content-Type": "application/json" },
+					'{ "session_id": 123 }'
+				);
+			});
+
 		});
 
 		describe('/v1/profile', function() {

--- a/test/3_api.js
+++ b/test/3_api.js
@@ -415,10 +415,12 @@ describe('Server', function() {
 			it ('should not include developer identity', function(done) {
 				var assert = testUtils.plan(1, done);
 				storage.set('use_jsonp', false);
-				storage.set('identity', '12345678');
+				/*
+				 * Branch instance will pass identity, if set, but resources will filter it out.
+				 */
 				server.request(
 					resources.open,
-					testUtils.params({}),
+					testUtils.params({ identity: '12345678' }),
 					storage,
 					assert.done
 				);

--- a/test/6_branch.js
+++ b/test/6_branch.js
@@ -584,17 +584,17 @@ describe('Branch', function() {
 	describe('setIdentity', function() {
 		basicTests('setIdentity', [ 1 ]);
 
-		var expectedRequest = testUtils.params(
-			{ "identity": "test_identity" },
-			[ "_t" ]
-		);
-		var expectedResponse = {
-			identity_id: '12345',
-			link: 'url',
-			referring_data: '{ }',
-			referring_identity: '12345'
-		};
 		it('should call api with identity', function(done) {
+			var expectedRequest = testUtils.params(
+				{ "identity": "test_identity" },
+				[ "_t" ]
+			);
+			var expectedResponse = {
+				identity_id: '12345',
+				link: 'url',
+				referring_data: '{ }',
+				referring_identity: '12345'
+			};
 			var branch = initBranch(true);
 			var assert = testUtils.plan(4, done);
 
@@ -607,11 +607,20 @@ describe('Branch', function() {
 			requests[0].callback(null, expectedResponse);
 			assert.deepEqual(requests[0].obj, expectedRequest, 'All params sent');
 		});
+
+		it('should update identity and identity_id in local storage', function(done) {
+			var branch = initBranch(true);
+			var assert = testUtils.plan(2, done);
+			branch.setIdentity('12345678', function(err, data) {
+				var localData = safejson.parse(localStorage.getItem('branch_session_first'));
+				assert.strictEqual(localData['identity'], '12345678');
+				assert.strictEqual(localData['identity_id'], '7654321');
+			});
+			requests[0].callback(null, { identity: '12345678', identity_id: '7654321' });
+		});
 	});
 
 	describe('setIdentity accepts empty data', function() {
-		basicTests('setIdentity', [ 1 ]);
-
 		var expectedRequest = testUtils.params(
 			{ "identity": "test_identity" },
 			[ "_t" ]

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -554,6 +554,7 @@
 		};
 
 		var assertions = [
+			'ok',
 			'fail',
 			'equal',
 			'notEqual',


### PR DESCRIPTION
The reported issue is that `/v1/open` returns 500 when the developer identity includes a space. The `identity` field should not be sent in an open request in the first place. It was added erroneously some time back to make developer identity show up in web session start events. The real problem is that the `identity_id` was not being picked up from storage at initialization, so a new `identity_id` was generated. With this change developer identity shows up in web session start events, even when it includes whitespace.

Related changes:
- `/v1/profile` returns a new identity_id (same session_id). This is now updated in storage.
- `/v1/pageview` ignores the identity field but requires the identity_id field.
- Return the `identity` from the open response in the init callback. This was always null.
- Added a button to the example.html template to exercise `branch.first()`. As a result of not storing the identity_id correctly, this method was not working.

@BranchMetrics/core-team 