### PR TITLE
[INTENG-11551] Allow short-link generation when tracking disabled

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -46,7 +46,8 @@ utils.userPreferences = {
 	whiteListedEndpointsWithData: {
 		'/v1/open': { 'link_identifier':'\\d+' },
 		'/v1/pageview': { 'event': 'pageview' },
-		'/v1/dismiss': { 'event': 'dismiss' }
+		'/v1/dismiss': { 'event': 'dismiss' },
+		'/v1/url': { }
 	},
 	allowErrorsInCallback: false,
 	shouldBlockRequest: function(url, requestData) {

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -85,7 +85,7 @@ describe('utils', function() {
 				},
 				"has_app": true,
 				"identity": "90210",
-				"developer_identity": "67890",
+				"developer_identity": "90210",
 				"referring_identity": "12345",
 				"referring_link": null
 			};


### PR DESCRIPTION
This just adds `/v1/url` to the endpoints that can be called with tracking disabled. It also includes a fix for a broken test after a recent change (the identity-related update). https://jdee.github.io/example.html has this change and a button to disable tracking. https://jdee.github.io/example-prod.html is the same thing pointing at prod.

SMS (INTENG-11512) is a little more involved, but also not too hard.

@BranchMetrics/core-team 