### PR TITLE
JRNYS-44: CLS score issue

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -87,14 +87,14 @@ EOF
 
   echo -en "${GREEN}Pushing to S3: branch-cdn ...${NC}\n"
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-cdn/branch-$VERSION.min.js --acl public-read --cache-control "max-age=300"
-  aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-cdn/branch-latest.min.js --acl public-read --cache-control "max-age=300"
+  # aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-cdn/branch-latest.min.js --acl public-read --cache-control "max-age=300"
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-cdn/branch-v2.0.0.min.js --acl public-read --cache-control "max-age=300"
   aws s3 cp example.html s3://branch-cdn/example.html --acl public-read
 
   # Pushing to QA builds
   echo -en "${GREEN}Pushing to S3: branch-builds ...${NC}\n"
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-$VERSION.min.js --acl public-read
-  aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-latest.min.js --acl public-read
+  # aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-latest.min.js --acl public-read
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-v2.0.0.min.js --acl public-read
   aws s3 cp --content-type="text/javascript" dist/build.js s3://branch-builds/websdk/branch.js --acl public-read
   aws s3 cp example.html s3://branch-builds/websdk/example.html --acl public-read
@@ -102,7 +102,7 @@ EOF
   # Invalidate cache at CDN
   echo -en "${GREEN}Invalidating cloudfrond distribution for WebSDK ...${NC}\n"
   aws configure set preview.cloudfront true
-  aws cloudfront create-invalidation --distribution-id E10P37NG0GMER --paths /branch-latest.min.js /example.html /branch-v2.0.0.min.js
+  # aws cloudfront create-invalidation --distribution-id E10P37NG0GMER --paths /branch-latest.min.js /example.html /branch-v2.0.0.min.js
 
   echo -en "${GREEN}Pushing git tags${NC}\n"
   git tag v$VERSION
@@ -160,7 +160,7 @@ elif [ "$CIRCLE_BRANCH" == 'master' ]; then
 
   echo -en "${GREEN}Pushing to S3: branch-builds ...${NC}\n"
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-$VERSION.min.js --acl public-read
-  aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-latest.min.js --acl public-read
+  # aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-latest.min.js --acl public-read
   aws s3 cp --content-type="text/javascript" --content-encoding="gzip" dist/build.min.js.gz s3://branch-builds/websdk/branch-v2.0.0.min.js --acl public-read
   aws s3 cp --content-type="text/javascript" dist/build.js s3://branch-builds/websdk/branch.js --acl public-read
   aws s3 cp example.html s3://branch-builds/websdk/example.html --acl public-read

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -44,8 +44,8 @@ journeys_utils.branch = null;
 journeys_utils.banner = null;
 journeys_utils.isJourneyDisplayed = false;
 
-journeys_utils.animationSpeed = 250;
-journeys_utils.animationDelay = 20;
+journeys_utils.animationSpeed = 550;
+journeys_utils.animationDelay = 140;
 
 // options to control a Journey's animations
 journeys_utils.exitAnimationDisabled = false;


### PR DESCRIPTION
Increased animationSpeed and animationDelay to improve CLS score. Scores on Google PageSpeed Insights went from 0.129 (red) to 0.054 (green).

https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fwwest-branch.github.io%2F%3F_branch_view_id%3D908103051678040066

We would like to deploy a version of the sdk that is not `branch-latest` so customers can test on their websites, hence the commenting out of lines that include `branch-latest` in the deploy.sh file. @yli-branch 

Closing as we found a better solution in the PR below:
https://github.com/BranchMetrics/web-branch-deep-linking-attribution/pull/776