### PR TITLE
Update rollbar.py to use python3

### DIFF
--- a/deployment/rollbar.py
+++ b/deployment/rollbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import requests
@@ -24,8 +24,8 @@ def rollbar_record_deploy():
             }, timeout=3)
 
             if resp.status_code == 200:
-                print "Deploy recorded successfully."
+                print("Deploy recorded successfully.")
             else:
-                print "Error recording deploy:", resp.text
+                print("Error recording deploy:", resp.text)
 
 rollbar_record_deploy()


### PR DESCRIPTION
rollbar.py currently uses python2, which doesn't have request library installed. This meant deploy step was failing at running deployment/rollbar.py step. This PR fixes rollbar.py to use python3, and updates print syntax to python3 syntax. 