### PR TITLE
[JRNYS-2][INTENG-11986] Avoid document.write()

### DIFF
--- a/src/4_banner_html.js
+++ b/src/4_banner_html.js
@@ -157,7 +157,11 @@ banner_html.iframe = function(options, action) {
 	var iframedoc = iframe.contentDocument || iframe.contentWindow.document;
 	iframedoc.head = iframedoc.createElement('head');
 	iframedoc.body = iframedoc.createElement('body');
-	iframedoc.body.innerHTML = html;
+	var containerDiv = iframedoc.createElement('div');
+	containerDiv.className = 'branch-animation';
+	containerDiv.id = 'branch-banner';
+	containerDiv.innerHTML = html;
+	iframedoc.body.append(containerDiv);
 	iframedoc.body.className = bodyClass;
 
 	return iframe;

--- a/src/4_banner_html.js
+++ b/src/4_banner_html.js
@@ -153,16 +153,12 @@ banner_html.iframe = function(options, action) {
 		bodyClass = 'branch-banner-desktop';
 	}
 
-	var html = banner_html.banner(options, action);
 	var iframedoc = iframe.contentDocument || iframe.contentWindow.document;
 	iframedoc.head = iframedoc.createElement('head');
 	iframedoc.body = iframedoc.createElement('body');
-	var containerDiv = iframedoc.createElement('div');
-	containerDiv.className = 'branch-animation';
-	containerDiv.id = 'branch-banner';
-	containerDiv.innerHTML = html;
-	iframedoc.body.append(containerDiv);
 	iframedoc.body.className = bodyClass;
+
+	banner_html.div(options, action, iframedoc);
 
 	return iframe;
 };
@@ -170,12 +166,13 @@ banner_html.iframe = function(options, action) {
 /**
  * @param {banner_utils.options} options
  */
-banner_html.div = function(options, action) {
+banner_html.div = function(options, action, doc) {
 	var banner = document.createElement('div');
 	banner.id = 'branch-banner';
 	banner.className = 'branch-animation';
 	banner.innerHTML = banner_html.banner(options, action);
-	document.body.appendChild(banner);
+	doc = doc || document;
+	doc.body.appendChild(banner);
 
 	return banner;
 };

--- a/src/4_banner_html.js
+++ b/src/4_banner_html.js
@@ -167,11 +167,12 @@ banner_html.iframe = function(options, action) {
  * @param {banner_utils.options} options
  */
 banner_html.div = function(options, action, doc) {
-	var banner = document.createElement('div');
+	doc = doc || document;
+
+	var banner = doc.createElement('div');
 	banner.id = 'branch-banner';
 	banner.className = 'branch-animation';
 	banner.innerHTML = banner_html.banner(options, action);
-	doc = doc || document;
 	doc.body.appendChild(banner);
 
 	return banner;

--- a/src/4_banner_html.js
+++ b/src/4_banner_html.js
@@ -153,14 +153,12 @@ banner_html.iframe = function(options, action) {
 		bodyClass = 'branch-banner-desktop';
 	}
 
-	var iframeHTML = '<html><head></head><body class="' +
-		bodyClass +
-		'"><div id="branch-banner" class="branch-animation">' +
-		banner_html.banner(options, action) +
-		'</body></html>';
-	iframe.contentWindow.document.open();
-	iframe.contentWindow.document.write(iframeHTML);
-	iframe.contentWindow.document.close();
+	var html = banner_html.banner(options, action);
+	var iframedoc = iframe.contentDocument || iframe.contentWindow.document;
+	iframedoc.head = iframedoc.createElement('head');
+	iframedoc.body = iframedoc.createElement('body');
+	iframedoc.body.innerHTML = html;
+	iframedoc.body.className = bodyClass;
 
 	return iframe;
 };

--- a/src/branch_view.js
+++ b/src/branch_view.js
@@ -38,8 +38,7 @@ function renderHtmlBlob(parent, html, hasApp) {
 
 	// create iframe element, add html, add css, add ctaText
 	var iframe = journeys_utils.createAndAppendIframe();
-	var iframeHTML = journeys_utils.createIframeInnerHTML(html, utils.mobileUserAgent());
-	journeys_utils.addHtmlToIframe(iframe, iframeHTML);
+	journeys_utils.addHtmlToIframe(iframe, html, utils.mobileUserAgent());
 	journeys_utils.addIframeOuterCSS(cssIframeContainer);
 	journeys_utils.addIframeInnerCSS(iframe, cssInsideIframe);
 	journeys_utils.addDynamicCtaText(iframe, ctaText);

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -248,7 +248,8 @@ journeys_utils.createAndAppendIframe = function() {
 /***
  * @function journeys_utils.addHtmlToIframe
  * @param {Object} iframe - iframe node created in previous step
- * @param {string} iframeHTML
+ * @param {string} html - raw Journey HTML
+ * @param {string} userAgent - UA to determine body class
  */
 journeys_utils.addHtmlToIframe = function(iframe, html, userAgent) {
 	var bodyClass;

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -262,7 +262,7 @@ journeys_utils.addHtmlToIframe = function(iframe, html, userAgent) {
 		bodyClass = 'branch-banner-desktop';
 	}
 
-	const iframedoc = iframe.contentDocument || iframe.contentWindow.document;
+	var iframedoc = iframe.contentDocument || iframe.contentWindow.document;
 	iframedoc.head = iframedoc.createElement('head');
 	iframedoc.body = iframedoc.createElement('body');
 	iframedoc.body.innerHTML = html;

--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -246,11 +246,11 @@ journeys_utils.createAndAppendIframe = function() {
 }
 
 /***
- * @function journeys_utils.createIframeInnerHTML
- * @param {string} html
- * @param {string} userAgent
+ * @function journeys_utils.addHtmlToIframe
+ * @param {Object} iframe - iframe node created in previous step
+ * @param {string} iframeHTML
  */
-journeys_utils.createIframeInnerHTML = function(html, userAgent) {
+journeys_utils.addHtmlToIframe = function(iframe, html, userAgent) {
 	var bodyClass;
 	if (userAgent === 'ios' || userAgent === 'ipad') {
 		bodyClass = 'branch-banner-ios';
@@ -262,24 +262,11 @@ journeys_utils.createIframeInnerHTML = function(html, userAgent) {
 		bodyClass = 'branch-banner-desktop';
 	}
 
-	var iframeHTML = '<html><head></head><body class="' +
-		bodyClass +
-		'">' +
-		html +
-		'</body></html>';
-
-	return iframeHTML;
-}
-
-/***
- * @function journeys_utils.addHtmlToIframe
- * @param {Object} iframe - iframe node created in previous step
- * @param {string} iframeHTML
- */
-journeys_utils.addHtmlToIframe = function(iframe, iframeHTML) {
-	iframe.contentWindow.document.open();
-	iframe.contentWindow.document.write(iframeHTML);
-	iframe.contentWindow.document.close();
+	const iframedoc = iframe.contentDocument || iframe.contentWindow.document;
+	iframedoc.head = iframedoc.createElement('head');
+	iframedoc.body = iframedoc.createElement('body');
+	iframedoc.body.innerHTML = html;
+	iframedoc.body.className = bodyClass;
 }
 
 /***

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -1202,4 +1202,44 @@ describe('utils', function() {
 			assert.equal(journeys_utils.tryReplaceJourneyCtaLink(html).replace(link, ""), htmlWithoutLink);
 		});
 	});
+
+	describe('addHtmlToIframe', function() {
+		var iframe = {
+			contentDocument: {
+				createElement: sinon.stub().returns({})
+			},
+			head: {},
+			body: {}
+		};
+
+		it('adds the specified HTML as the body.innerHTML of the supplied iframe', function(done) {
+			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ios');
+			assert.equal(iframe.contentDocument.body.innerHTML, '<p>A paragraph</p>');
+			done();
+		});
+
+		it('sets the body class to branch-banner-ios when UA is ios', function(done) {
+			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ios');
+			assert.equal(iframe.contentDocument.body.className, 'branch-banner-ios');
+			done();
+		});
+
+		it('sets the body class to branch-banner-ios when UA is ipad', function(done) {
+			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ipad');
+			assert.equal(iframe.contentDocument.body.className, 'branch-banner-ios');
+			done();
+		});
+
+		it('sets the body class to branch-banner-android when UA is android', function(done) {
+			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'android');
+			assert.equal(iframe.contentDocument.body.className, 'branch-banner-android');
+			done();
+		});
+
+		it('sets the body class to branch-banner-desktop when UA is any other value', function(done) {
+			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', '');
+			assert.equal(iframe.contentDocument.body.className, 'branch-banner-desktop');
+			done();
+		});
+	});
 });

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -1206,7 +1206,9 @@ describe('utils', function() {
 	describe('addHtmlToIframe', function() {
 		var iframe = {
 			contentDocument: {
-				createElement: sinon.stub().returns({})
+				createElement: function() {
+					return {};
+				}
 			},
 			head: {},
 			body: {}

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -1214,34 +1214,29 @@ describe('utils', function() {
 			body: {}
 		};
 
-		it('adds the specified HTML as the body.innerHTML of the supplied iframe', function(done) {
+		it('adds the specified HTML as the body.innerHTML of the supplied iframe', function() {
 			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ios');
 			assert.equal(iframe.contentDocument.body.innerHTML, '<p>A paragraph</p>');
-			done();
 		});
 
-		it('sets the body class to branch-banner-ios when UA is ios', function(done) {
+		it('sets the body class to branch-banner-ios when UA is ios', function() {
 			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ios');
 			assert.equal(iframe.contentDocument.body.className, 'branch-banner-ios');
-			done();
 		});
 
-		it('sets the body class to branch-banner-ios when UA is ipad', function(done) {
+		it('sets the body class to branch-banner-ios when UA is ipad', function() {
 			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'ipad');
 			assert.equal(iframe.contentDocument.body.className, 'branch-banner-ios');
-			done();
 		});
 
-		it('sets the body class to branch-banner-android when UA is android', function(done) {
+		it('sets the body class to branch-banner-android when UA is android', function() {
 			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', 'android');
 			assert.equal(iframe.contentDocument.body.className, 'branch-banner-android');
-			done();
 		});
 
-		it('sets the body class to branch-banner-desktop when UA is any other value', function(done) {
+		it('sets the body class to branch-banner-desktop when UA is any other value', function() {
 			journeys_utils.addHtmlToIframe(iframe, '<p>A paragraph</p>', '');
 			assert.equal(iframe.contentDocument.body.className, 'branch-banner-desktop');
-			done();
 		});
 	});
 });


### PR DESCRIPTION
This does not directly impact page rating by Google PageSpeed, but it eliminates diagnostic warnings about `document.write()`. The SDK has been just constructing a web page as text in memory and then shoving it into an iframe. This change modifies the DOM elements on the iframe directly instead, collapsing two utility functions into one.

This change is preliminary but has been deployed at https://jdee.github.io/pure-journeys-demo. [This page](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fjdee.github.io%2Fpure-journeys-demo) no longer shows complaints about document.write().

There is a similar place in a code path called by `branch.banner()` that ~~could be~~ has been addressed in the same way but does not affect Google PageSpeed diagnostics. Unit tests ought to be provided for this. All existing unit tests still pass with these changes.

@BranchMetrics/core-team 