### PR TITLE
[patch] INTENG-10581 Stringifies null values in custom data

### DIFF
--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -1206,17 +1206,17 @@ utils.getCurrentUrl = function() {
 	return utils.isIframeAndFromSameOrigin() ? window.top.location.href : window.location.href;
 };
 
-utils.convertObjectValueToString = function(valueToConvert) {
-	if (utils.validateParameterType(valueToConvert, 'object')) {
-		return safejson.stringify(valueToConvert);
+utils.convertValueToString = function(value) {
+	if (utils.validateParameterType(value, 'object')) {
+		return safejson.stringify(value);
 	}
-	if (utils.validateParameterType(valueToConvert, 'array')) {
-		return safejson.stringify(valueToConvert);
+	if (utils.validateParameterType(value, 'array')) {
+		return safejson.stringify(value);
 	}
-	if (valueToConvert === null) {
+	if (value === null) {
 		return 'null';
 	}
-	return valueToConvert.toString();
+	return value.toString();
 };
 
 // Required for logEvent()'s custom_data object - values must be converted to string
@@ -1226,7 +1226,7 @@ utils.convertObjectValuesToString = function(objectToConvert) {
 	}
 	for (var key in objectToConvert) {
 		if (objectToConvert.hasOwnProperty(key)) {
-			objectToConvert[key] = utils.convertObjectValueToString(objectToConvert[key]);
+			objectToConvert[key] = utils.convertValueToString(objectToConvert[key]);
 		}
 	}
 	return objectToConvert;

--- a/src/1_utils.js
+++ b/src/1_utils.js
@@ -1206,6 +1206,19 @@ utils.getCurrentUrl = function() {
 	return utils.isIframeAndFromSameOrigin() ? window.top.location.href : window.location.href;
 };
 
+utils.convertObjectValueToString = function(valueToConvert) {
+	if (utils.validateParameterType(valueToConvert, 'object')) {
+		return safejson.stringify(valueToConvert);
+	}
+	if (utils.validateParameterType(valueToConvert, 'array')) {
+		return safejson.stringify(valueToConvert);
+	}
+	if (valueToConvert === null) {
+		return 'null';
+	}
+	return valueToConvert.toString();
+};
+
 // Required for logEvent()'s custom_data object - values must be converted to string
 utils.convertObjectValuesToString = function(objectToConvert) {
 	if (!utils.validateParameterType(objectToConvert, 'object') || Object.keys(objectToConvert).length === 0) {
@@ -1213,7 +1226,7 @@ utils.convertObjectValuesToString = function(objectToConvert) {
 	}
 	for (var key in objectToConvert) {
 		if (objectToConvert.hasOwnProperty(key)) {
-			objectToConvert[key] = utils.validateParameterType(objectToConvert[key], 'object') || utils.validateParameterType(objectToConvert[key], 'array') ? safejson.stringify(objectToConvert[key]) : objectToConvert[key].toString();
+			objectToConvert[key] = utils.convertObjectValueToString(objectToConvert[key]);
 		}
 	}
 	return objectToConvert;

--- a/test/1_utils.js
+++ b/test/1_utils.js
@@ -653,6 +653,61 @@ describe('utils', function() {
 		});
 	});
 
+	describe('convertValueToString', function() {
+		it('should stringify a number', function() {
+			var initial = 0;
+			var expected = "0";
+			assert.strictEqual(
+				expected,
+				utils.convertValueToString(initial),
+				"0 should be converted to \"0\""
+			);
+		});
+
+		it('should stringify a boolean', function() {
+			var initial = true;
+			var expected = "true";
+			assert.strictEqual(
+				expected,
+				utils.convertValueToString(initial),
+				"true should be converted to \"true\""
+			);
+		});
+
+		it('should stringify null', function() {
+			var initial = null;
+			var expected = "null";
+			assert.strictEqual(
+				expected,
+				utils.convertValueToString(initial),
+				"null should be converted to \"null\""
+			);
+		});
+
+		it('should stringify an object', function() {
+			var initial = { "sku": "foo-sku-7", "price": 8.50, "quantity": 4 };
+			var expected = "{\"sku\":\"foo-sku-7\",\"price\":8.5,\"quantity\":4}";
+			assert.strictEqual(
+				expected,
+				utils.convertValueToString(initial),
+				"object should be stringified"
+			);
+		});
+
+		it('should stringify an array', function() {
+			var initial = [
+				{ "sku": "foo-sku-7", "price": 8.50, "quantity": 4 },
+				'testing'
+			];
+			var expected = "[{\"sku\":\"foo-sku-7\",\"price\":8.5,\"quantity\":4},\"testing\"]";
+			assert.strictEqual(
+				expected,
+				utils.convertValueToString(initial),
+				"array should be stringified"
+			);
+		});
+	});
+
 
 	describe('setJourneyLinkData', function() {
 		it('should set journeys_utils.journeyLinkData with bannerid and journey link data', function() {


### PR DESCRIPTION
Calls to logEvent stringify events' custom data. Previously this didn't handle null values, leading to unhandled errors when null values were set on custom data keys (keys outside of [this list](https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/06a0faea2ed7eea459fd0457c11e8113d87549d5/src/1_utils.js#L1109)). This PR allows null values in logged event data. 