### PR TITLE
SDK-1456 - remove deprecated request library

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,3 @@
-var request = require('request');
 
 var safari_browsers = [
 	{

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
 	"dependencies": {
 		"google-closure-compiler": "^20220601.0.0",
 		"google-closure-deps": "^20220502.0.0",
-		"google-closure-library": "^20220502.0.0",
-		"request": "^2.55.0"
+		"google-closure-library": "^20220502.0.0"
 	},
 	"build": "2.62.0"
 }


### PR DESCRIPTION
# Description

- This removes the unused & deprecated request library


## Motivation and Context
Security concern about using a deprecated  old library, request.
![NPM - Branch SDK](https://user-images.githubusercontent.com/102190347/173414648-91903140-1023-4582-b5d2-7fcb95e6dcef.png)



## Addresses # (requirement) : `SDK-1456`

## Type of change
 :white_check_mark: bug fix

## How Has This Been Tested?

:white_check_mark: Integration test

## Build
|  | Before  | After  |
| :---         |     :---:      |          ---: |
| dist/build.js   | 160kb     | 160kb  |
| dist/build.min.js    | 80kb      | 80kb   |

## Checklist:

-  :white_check_mark: My code follows the style guidelines of this project
-  :white_check_mark: I have performed a self-review of my code
-  :white_check_mark: I have commented my code, particularly in hard-to-understand areas
-  :white_check_mark: I have made corresponding changes to the documentation
-  :white_check_mark: I have added tests that prove my fix is effective or that my feature works
-  :white_check_mark: New and existing unit tests pass locally with my changes
