### PR TITLE
SDK-1587 : fix cdn example not loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ EXTERN=src/extern.js
 
 VERSION=$(shell grep "version" package.json | perl -pe 's/\s+"version": "(.*)",/$$1/')
 
-ONPAGE_RELEASE=$(subst ",\",$(shell perl -pe 'BEGIN{$$sub="https://cdn.branch.io/branch-latest.min.js"};s\#SCRIPT_URL_HERE\#$$sub\#' src/onpage.js | $(COMPILER) | node transform.js branch_sdk))
+ONPAGE_RELEASE=$(subst ",\",$(shell perl -pe 'BEGIN{$$sub="https://cdn.branch.io/branch-latest.min.js"};s\#SCRIPT_URL_HERE\#$$sub\#' src/onpage.js | $(CLOSURE_COMPILER) | node transform.js branch_sdk))
 ONPAGE_DEV=$(subst ",\",$(shell perl -pe 'BEGIN{$$sub="dist/build.min.js"};s\#SCRIPT_URL_HERE\#$$sub\#' src/onpage.js | $(CLOSURE_COMPILER) | node transform.js branch_sdk))
 ONPAGE_TEST=$(subst ",\",$(shell perl -pe 'BEGIN{$$sub="../dist/build.js"};s\#SCRIPT_URL_HERE\#$$sub\#' src/onpage.js | $(CLOSURE_COMPILER) | node transform.js branch_sdk))
 


### PR DESCRIPTION
## Description

Web sdk example on the cdn at “https://cdn.branch.io/example.html” is failing to load the web sdk. It's missing part of the initialization code.
Root cause : Variable `COMPILER` no longer exists in the make file and needs to be replaced by `CLOSURE_COMPILER`
Workflow : 
- make file is invoked with release parameter from the deployment script here
 https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/08274373460a96739f2ddd54a652168cfec3f423/deployment/deploy.sh#L79
- make file internally converts example.template to example.html here
https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/08274373460a96739f2ddd54a652168cfec3f423/Makefile#L62
- then the generated example.html is uploaded to s3, cdn inside the deployment script here
https://github.com/BranchMetrics/web-branch-deep-linking-attribution/blob/08274373460a96739f2ddd54a652168cfec3f423/deployment/deploy.sh#L92


Fixes # (issue) : https://branch.atlassian.net/browse/SDK-1587

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran make script with release option and verified the generated example.html, verified linting, unit tests, integration tests have no regressions.

- [ ] Unit test
- [x] Integration test

## JS Budget Check

Please mention the size in kb before abd after this PR

| Files            | Before      | After       | 
| -----------      | ----------- | ----------- |
| dist/build.js.   |      165kb       |   165kb          |
| dist/build.min.js|       78kb      |     78kb        |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.
