### PR TITLE
APPSEC-482:  sanitize cdn example

### DIFF
--- a/example.html
+++ b/example.html
@@ -149,9 +149,9 @@
 		});
 		$('#setIdentity').click(function() {
 			var identity = getInputVal('#identityID');
-			request.html("branch.setIdentity('" + identity + "');");
+			request.text("branch.setIdentity('" + identity + "');");
 			branch.setIdentity(identity, function(err, data) {
-				response.html(err || JSON.stringify(data));
+				response.text(err || JSON.stringify(data));
 			});
 		});
 		$('#logout').click(function() {

--- a/example.html
+++ b/example.html
@@ -126,7 +126,7 @@
 			else {
 				inputElement.parent().removeClass('has-error');
 			}
-			return inputElement.val();
+			return DOMPurify.sanitize(inputElement.val());
 		};
 		$('#init').click(function() {
 			request.html('branch.init();');
@@ -317,5 +317,6 @@ branch.logEvent(
 			});
 		});
 	</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.1/purify.min.js"></script>
 </body>
 </html>

--- a/src/web/example.template.html
+++ b/src/web/example.template.html
@@ -149,9 +149,9 @@
 		});
 		$('#setIdentity').click(function() {
 			var identity = getInputVal('#identityID');
-			request.html("branch.setIdentity('" + identity + "');");
+			request.text("branch.setIdentity('" + identity + "');");
 			branch.setIdentity(identity, function(err, data) {
-				response.html(err || JSON.stringify(data));
+				response.text(err || JSON.stringify(data));
 			});
 		});
 		$('#logout').click(function() {

--- a/src/web/example.template.html
+++ b/src/web/example.template.html
@@ -126,7 +126,7 @@
 			else {
 				inputElement.parent().removeClass('has-error');
 			}
-			return inputElement.val();
+			return DOMPurify.sanitize(inputElement.val());
 		};
 		$('#init').click(function() {
 			request.html('branch.init();');
@@ -317,5 +317,6 @@ branch.logEvent(
 			});
 		});
 	</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.1/purify.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

- Santizes input values for setIdentity before including them in the API requests.
- uses text() method in place of html() to avoid rendering malformed html strigs given as user input for setIdentity


Fixes # (issue) : APPSEC-482

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit test
- [x] Integration test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.

cc @BranchMetrics/saas-sdk-devs for visibility.
