### PR TITLE
[SDK-2072] Create GHA to sync release notes with ReadMe Version History

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -1,0 +1,96 @@
+name: Update Version History on Readme
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Format and publish release notes to version history doc
+      id: update
+      run: |
+        # Get release name, body, and date from the release event
+        release_name="${{ github.event.release.tag_name }}"
+        release_body="${{ github.event.release.body }}"
+        release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
+        # Format release notes
+        formatted_notes="## $release_name\n\n**($release_date)**\n\n$release_body"
+        
+        # Get existing version history page
+        existing_content=$(curl --request GET \
+            --url https://dash.readme.com/api/v1/docs/web-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            | jq -r '.body')
+    
+        # Prepend new release notes to existing content
+        new_content=$(echo -e "$formatted_notes\n\n$existing_content")
+        payload=$(jq -n --arg nc "$new_content" '{"body": $nc}')
+
+        # Update version history page with new release notes
+        curl --request PUT \
+            --url https://dash.readme.com/api/v1/docs/web-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            --header 'content-type: application/json' \
+            --data "$payload"
+
+    - name: Announce New Release in Slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: "CDFGXRM9S"
+        payload: |
+            {
+                "text": "New Release: Branch Web SDK ${{ github.event.release.tag_name }}",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":rocket: New Release: Branch Web SDK ${{ github.event.release.tag_name }}",                            
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":star: *What's New*"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ${{ toJSON(github.event.release.body) }}
+                        }
+                	},
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": ":git: GitHub Release",
+                                    "emoji": true
+                                },
+                                "value": "github",
+                                "action_id": "github",
+                                "url": "${{ github.event.release.html_url }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+    env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_SDK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

Created a new Github Action that runs whenever a new Github Release is made. It uses the release tag and description to create a new section in the [public readme doc's version history page](https://help.branch.io/developers-hub/docs/web-version-history). It also uses this data to send a Slack message in the SDK channel announcing the new release.

## Fixes # (issue)
SDK-2072 -- Help Docs automate Readme changelogs

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Using Act and actual releases in a test repo.

- [ ] Unit test
- [ ] Integration test

## JS Budget Check

Please mention the size in kb before abd after this PR

| Files            | Before      | After       | 
| -----------      | ----------- | ----------- |
| dist/build.js.   |             |             |
| dist/build.min.js|             |             |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.

cc @BranchMetrics/saas-sdk-devs for visibility.
