### PR TITLE
Revert "fix(SDK-2037): remove session_id check to determine when to call v1/open"

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -575,7 +575,7 @@ Branch.prototype['init'] = wrap(
 				}
 			}
 		};
-		if (sessionData && !link_identifier && !utils.getParamValue('branchify_url')) {
+		if (sessionData && sessionData['session_id'] && !link_identifier && !utils.getParamValue('branchify_url')) {
 			// resets data in session storage to prevent previous link click data from being returned to Branch.init()
 			session.update(self._storage, { "data": "" });
 			session.update(self._storage, { "referring_link": "" });


### PR DESCRIPTION
Reverts BranchMetrics/web-branch-deep-linking-attribution#919
- session_id check is needed during re-initialization scenarios like disableTracking(false) after disableTracking(true)
