### PR TITLE
[ACQ-848] feat(journeys): add dismissJourney() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ index.html
 dist
 .nyc_output
 test-results.json
+.idea

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1700,6 +1700,21 @@ Branch.prototype['closeJourney'] = wrap(callback_params.CALLBACK_ERR, function(d
 	done();
 });
 
+Branch.prototype['dismissJourney'] = wrap(callback_params.CALLBACK_ERR, function(done) {
+  var self = this;
+  self['renderQueue'](function() {
+    if (journeys_utils.banner && journeys_utils.isJourneyDisplayed) {
+      self._publishEvent('didCallJourneyDismiss', journeys_utils.journeyLinkData);
+      journeys_utils.animateBannerExit(journeys_utils.banner);
+      journeys_utils._setJourneyDismiss(journeys_utils.branch._storage, journeys_utils.journeyLinkData["journey_link_data"]["view_id"], journeys_utils.journeyLinkData["journey_link_data"]["journey_id"]);
+    }
+    else {
+      return done('Journey already dismissed.');
+    }
+  });
+  done();
+});
+
 Branch.prototype['banner'] = wrap(callback_params.CALLBACK_ERR, function(done, options, data) {
 	var banner_deprecation_msg = 'The "banner" method is deprecated and will be removed in future versions. Please use Branch Journeys instead. For more information and migration steps, visit: https://help.branch.io/using-branch/docs/journeys-overview';
 	console.warn(banner_deprecation_msg);


### PR DESCRIPTION
ACQ-848: adding a dismissJourney() method as closeJourney() doesn't do what we need. It still allows for the journey to reappear. This allows for the localstorage value to be written, and does what we intend.