### PR TITLE
[patch] use binary encoding function that does not overflow for qr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist
 dev
 .nyc_output
 test-results.json
+.idea/

--- a/example.html
+++ b/example.html
@@ -83,7 +83,6 @@
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="https://cdn.branch.io/branch-latest.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener banner closeBanner closeJourney data deepview deepviewCta first init link logout removeListener setBranchViewData setIdentity track trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback qrCode setRequestMetaData setDMAParamsForEEA setAPIUrl getAPIUrl".split(" "), 0);
-		branch.setAPIUrl("https://api.stage.branch.io");
 
 		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
 			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));

--- a/example.html
+++ b/example.html
@@ -83,6 +83,7 @@
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 	<script type="text/javascript">
 		(function(b,r,a,n,c,h,_,s,d,k){if(!b[n]||!b[n]._q){for(;s<_.length;)c(h,_[s++]);d=r.createElement(a);d.async=1;d.src="https://cdn.branch.io/branch-latest.min.js";k=r.getElementsByTagName(a)[0];k.parentNode.insertBefore(d,k);b[n]=h}})(window,document,"script","branch",function(b,r){b[r]=function(){b._q.push([r,arguments])}},{_q:[],_v:1},"addListener banner closeBanner closeJourney data deepview deepviewCta first init link logout removeListener setBranchViewData setIdentity track trackCommerceEvent logEvent disableTracking getBrowserFingerprintId crossPlatformIds lastAttributedTouchData setAPIResponseCallback qrCode setRequestMetaData setDMAParamsForEEA setAPIUrl getAPIUrl".split(" "), 0);
+		branch.setAPIUrl("https://api.stage.branch.io");
 
 		branch.setAPIResponseCallback(function(url, method, requestBody, error, status, responseBody) {
 			console.log('Request: ' + method + ' ' + url + ' body=' + JSON.stringify(requestBody));

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1340,19 +1340,22 @@ Branch.prototype['qrCode'] = wrap(
 		this._api(
 			resources.qrCode,
 			utils.cleanLinkData(linkData),
-			function(error, rawBuffer) {
-				function QrCode() { }
-				if (!error) {
-					QrCode['rawBuffer'] = rawBuffer;
-					QrCode['base64'] = function() {
-						// First Encode array buffer as UTF-8 String, then Base64 Encode
-						if (this['rawBuffer']) {
-							return btoa(String.fromCharCode.apply(null, new Uint8Array(this['rawBuffer'])));
-						}
-						throw Error('QrCode.rawBuffer is empty.');
-					};
-				}
-				return done(error || null, QrCode || null);
+			(error, rawBuffer) => {
+				if (error) return done(error, null);
+
+				const QrCode = {
+					rawBuffer,
+					base64() {
+						if (!this.rawBuffer) throw new Error('QrCode.rawBuffer is empty.');
+						// Encode the Uint8Array to a binary string, then convert to base64
+						const binaryString = Array.from(new Uint8Array(this.rawBuffer))
+							.map(byte => String.fromCharCode(byte))
+							.join('');
+						return btoa(binaryString);
+					}
+				};
+
+				return done(null, QrCode);
 			}
 		);
 	}

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1342,7 +1342,6 @@ Branch.prototype['qrCode'] = wrap(
 			utils.cleanLinkData(linkData),
 			function(error, rawBuffer) {
 				function QrCode() { }
-
 				if (!error) {
 					QrCode['rawBuffer'] = rawBuffer;
 					QrCode['base64'] = function() {


### PR DESCRIPTION
# Pull Request Template

## Description

If the qr codes get too big (in total file size), then the current function will blow up. This one works better, tested manually by updating the dist/build.js, and updating example.html to point to that instead of the production cdn hosted websdk

I couldnt get this new one to overflow

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit test
- [ ] Integration test

## JS Budget Check

Please mention the size in kb before abd after this PR

| Files            | Before      | After       | 
| -----------      | ----------- | ----------- |
| dist/build.js.   |             |             |
| dist/build.min.js|             |             |

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.

cc @BranchMetrics/saas-sdk-devs for visibility.
