### PR TITLE
fix(journeys): guard empty journey_link_data in setJourneyLinkData (EMT-3772)

### DIFF
--- a/src/journeys_utils.js
+++ b/src/journeys_utils.js
@@ -1027,6 +1027,7 @@ journeys_utils.setJourneyLinkData = function(linkData) {
 		utils.merge(data['journey_link_data'], linkData);
 	}
 	journeys_utils.journeyLinkData = data;
+	data['journey_link_data'] = data['journey_link_data'] || {};
 	journeys_utils.journeyType = data['journey_link_data']['type'] || null;
 	journeys_utils.isDesktopJourney = data['journey_link_data']['type'] === "desktop";
 	journeys_utils.journeyVariant = data['journey_link_data']['variant'] || null;

--- a/test/journeys_utils.js
+++ b/test/journeys_utils.js
@@ -46,3 +46,30 @@ describe('getRelativeHeightValueOrFalseFromBannerHeight', function() {
     assert.strictEqual(journeys_utils.getRelativeHeightValueOrFalseFromBannerHeight(bannerHeight), expected, '5 from bannerHeight of 5%');
   });
 });
+
+describe('setJourneyLinkData', function() {
+  const assert = testUtils.unplanned();
+
+  it('should not throw and should null journey fields when linkData is an empty object', function() {
+    assert.doesNotThrow(function() {
+      journeys_utils.setJourneyLinkData({});
+    }, 'empty journey_link_data must not throw');
+    assert.strictEqual(journeys_utils.journeyType, null, 'journeyType null when empty');
+    assert.strictEqual(journeys_utils.isDesktopJourney, false, 'isDesktopJourney false when empty');
+    assert.strictEqual(journeys_utils.journeyVariant, null, 'journeyVariant null when empty');
+  });
+
+  it('should not throw when linkData is undefined', function() {
+    assert.doesNotThrow(function() {
+      journeys_utils.setJourneyLinkData(undefined);
+    }, 'undefined journey_link_data must not throw');
+    assert.strictEqual(journeys_utils.journeyType, null, 'journeyType null when undefined');
+  });
+
+  it('should read type and variant when linkData is populated', function() {
+    journeys_utils.setJourneyLinkData({ 'type': 'desktop', 'variant': 'a' });
+    assert.strictEqual(journeys_utils.journeyType, 'desktop', 'journeyType from populated data');
+    assert.strictEqual(journeys_utils.isDesktopJourney, true, 'isDesktopJourney true for desktop type');
+    assert.strictEqual(journeys_utils.journeyVariant, 'a', 'journeyVariant from populated data');
+  });
+});


### PR DESCRIPTION
## Summary

`journeys_utils.setJourneyLinkData(linkData)` read `data['journey_link_data']['type']` (and `['variant']`) **unconditionally**, but only assigned `data['journey_link_data']` when `linkData` was a **non-empty** object. When `journey_link_data` was `{}` (or absent), `data['journey_link_data']` was `undefined` and the read threw `TypeError: Cannot read properties of undefined (reading 'type')`, aborting the Journey/banner render.

In production `journey_link_data` is normally populated, so it does not surface for typical Journeys — but any path delivering an empty value breaks the banner.

## Fix

Default the object before the reads in `src/journeys_utils.js`:

```js
data['journey_link_data'] = data['journey_link_data'] || {};
```

Normal behavior (populated data) is unchanged; for the empty/absent case, `journeyType`/`journeyVariant` resolve to `null` and `isDesktopJourney` to `false`.

## Tests

Added a `setJourneyLinkData` describe block in `test/journeys_utils.js` covering:
- empty object `{}` (the regression)
- `undefined`
- populated `linkData` (normal path)

Verified the tests are genuine regression tests — they fail without the fix with the exact `TypeError` from the ticket, and pass with it.

- `make` (Closure build): 0 errors
- `npm test`: 158 passing

## Ticket

[EMT-3772](https://branch.atlassian.net/browse/EMT-3772)

## Out of scope, noticed in passing

`.mocharc.js` only runs 5 of the 10 test files; ~146 tests in `2_storage.js`, `3_api.js`, `6_branch.js`, `7_integration.js`, and `journeys.js` are not executed by `npm test`/CI. Worth a separate ticket to triage/re-enable — not addressed here to keep this PR surgical.

[EMT-3772]: https://branch.atlassian.net/browse/EMT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ