### PR TITLE
[patch] ENGMT-4290: preserve setRequestMetaData() on v1/pageview and v1/dismiss

### DIFF
--- a/src/3_api.js
+++ b/src/3_api.js
@@ -129,6 +129,11 @@
 	else if (resource.endpoint === '/v1/pageview' || resource.endpoint === '/v1/dismiss') {
 		utils.merge(d, data);
 		if (d['branch_requestMetadata']) {
+			// v1/pageview and v1/dismiss already use 'metadata' for Journeys/view data
+			// (see branch_view._getPageviewRequestData), so nest setRequestMetaData()'s
+			// output under its own key instead of overwriting that object.
+			d['metadata'] = d['metadata'] || {};
+			d['metadata']['branch_requestMetadata'] = d['branch_requestMetadata'];
 			delete d['branch_requestMetadata'];
 		}
 	}

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1991,7 +1991,8 @@ Branch.prototype['setDMAParamsForEEA'] = wrap(callback_params.CALLBACK_ERR, func
  * @function Branch.setRequestMetaData
  * @param {String} key - Request metadata key
  * @param {String} value - Request metadata value
- * Sets request metadata that gets passed along with all the API calls except v1/pageview
+ * Sets request metadata that gets passed along with all the API calls, including
+ * v1/pageview and v1/dismiss (nested under metadata.branch_requestMetadata for those two).
  */
 Branch.prototype['setRequestMetaData'] = function(key, value) {
 	try {

--- a/test/6_branch_new.js
+++ b/test/6_branch_new.js
@@ -62,10 +62,6 @@ describe('Branch - new', function() {
 		});
 	});
 	describe('pageview/dismiss request metadata', function() {
-		// Built inline (mirroring resources.pageview/resources.dismiss in src/2_resources.js)
-		// rather than via goog.require('resources'), since that module re-declares
-		// `var resources` after goog.provide('resources'), which shadows the populated
-		// object in this CJS-based test harness and leaves the global stub empty.
 		var pageviewResource = {
 			destination: config.api_endpoint,
 			endpoint: '/v1/pageview',

--- a/test/6_branch_new.js
+++ b/test/6_branch_new.js
@@ -6,6 +6,9 @@ var sinon = require('sinon');
 goog.require('Branch');
 goog.require('utils');
 goog.require('task_queue');
+goog.require('Server');
+goog.require('config');
+goog.require('safejson');
 
 describe('Branch - new', function() {
 	const sandbox = sinon.createSandbox();
@@ -56,6 +59,52 @@ describe('Branch - new', function() {
 			assert.strictEqual(result2, undefined);
 			sinon.assert.notCalled(addPropertyIfNotNullSpy);
 			assert.deepEqual(requestMetadata, { "key": "value" });
+		});
+	});
+	describe('pageview/dismiss request metadata', function() {
+		// Built inline (mirroring resources.pageview/resources.dismiss in src/2_resources.js)
+		// rather than via goog.require('resources'), since that module re-declares
+		// `var resources` after goog.provide('resources'), which shadows the populated
+		// object in this CJS-based test harness and leaves the global stub empty.
+		var pageviewResource = {
+			destination: config.api_endpoint,
+			endpoint: '/v1/pageview',
+			method: utils.httpMethod.POST
+		};
+		var dismissResource = {
+			destination: config.api_endpoint,
+			endpoint: '/v1/dismiss',
+			method: utils.httpMethod.POST
+		};
+
+		it('should nest branch_requestMetadata inside metadata for v1/pageview instead of dropping it', function() {
+			var server = new Server();
+			var result = server.getUrl(pageviewResource, {
+				branch_key: window.branch_sample_key,
+				event: 'pageview',
+				metadata: { url: 'http://example.com' },
+				branch_requestMetadata: { '$marketing_cloud_visitor_id': '12345' }
+			});
+			assert.strictEqual(typeof result.error, 'undefined');
+			var metadataMatch = decodeURIComponent(result.data).match(/metadata=(.+?)(&|$)/);
+			var metadata = safejson.parse(metadataMatch[1]);
+			assert.deepEqual(metadata.branch_requestMetadata, { '$marketing_cloud_visitor_id': '12345' });
+			assert.strictEqual(metadata.url, 'http://example.com');
+			assert.strictEqual(result.data.indexOf('branch_requestMetadata='), -1, 'not sent as a top-level field');
+		});
+
+		it('should nest branch_requestMetadata inside metadata for v1/dismiss instead of dropping it', function() {
+			var server = new Server();
+			var result = server.getUrl(dismissResource, {
+				branch_key: window.branch_sample_key,
+				event: 'dismiss',
+				metadata: {},
+				branch_requestMetadata: { '$marketing_cloud_visitor_id': '12345' }
+			});
+			assert.strictEqual(typeof result.error, 'undefined');
+			var metadataMatch = decodeURIComponent(result.data).match(/metadata=(.+?)(&|$)/);
+			var metadata = safejson.parse(metadataMatch[1]);
+			assert.deepEqual(metadata.branch_requestMetadata, { '$marketing_cloud_visitor_id': '12345' });
 		});
 	});
 	describe('setDMAParamsForEEA', function() {


### PR DESCRIPTION
setRequestMetaData() was silently dropped for pageview/dismiss requests (regression from #970, which deleted branch_requestMetadata outright to fix it leaking into the POST body as an unstringified, dot-flattened field). Instead of dropping it, nest it under metadata.branch_requestMetadata so it can't collide with the Journeys/view metadata already living in that field for these two endpoints, then let the existing stringify step serialize it safely as part of the whole metadata object.

Adds unit tests confirming the metadata is nested correctly and that no malformed top-level branch_requestMetadata field leaks into the request.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit test
- [ ] Integration test

## JS Budget Check

Please mention the size in kb before and after this PR

| Files            | Before      | After       | 
| -----------      | ----------- | ----------- |
| dist/build.js.   |             |             |
| dist/build.min.js|             |             |

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.

cc @BranchMetrics/saas-sdk-devs for visibility.
