### PR TITLE
[patch] ENGMT-4290: update setRequestMetaData() on v1/pageview and v1/dismiss to store without nested att

### DIFF
--- a/src/3_api.js
+++ b/src/3_api.js
@@ -129,11 +129,13 @@
 	else if (resource.endpoint === '/v1/pageview' || resource.endpoint === '/v1/dismiss') {
 		utils.merge(d, data);
 		if (d['branch_requestMetadata']) {
-			// v1/pageview and v1/dismiss already use 'metadata' for Journeys/view data
-			// (see branch_view._getPageviewRequestData), so nest setRequestMetaData()'s
-			// output under its own key instead of overwriting that object.
-			d['metadata'] = d['metadata'] || {};
-			d['metadata']['branch_requestMetadata'] = d['branch_requestMetadata'];
+			// Merge setRequestMetaData()'s output directly into metadata, same as every
+			// other endpoint (flat, not nested under its own key). Note: v1/pageview and
+			// v1/dismiss already populate 'metadata' with Journeys/view data (url,
+			// user_agent, screen_width, etc. - see branch_view._getPageviewRequestData),
+			// so a setRequestMetaData() key that happens to match one of those names
+			// will silently overwrite it (or vice versa, depending on merge order).
+			d['metadata'] = utils.merge(d['metadata'] || {}, d['branch_requestMetadata']);
 			delete d['branch_requestMetadata'];
 		}
 	}

--- a/src/3_api.js
+++ b/src/3_api.js
@@ -129,12 +129,6 @@
 	else if (resource.endpoint === '/v1/pageview' || resource.endpoint === '/v1/dismiss') {
 		utils.merge(d, data);
 		if (d['branch_requestMetadata']) {
-			// Merge setRequestMetaData()'s output directly into metadata, same as every
-			// other endpoint (flat, not nested under its own key). Note: v1/pageview and
-			// v1/dismiss already populate 'metadata' with Journeys/view data (url,
-			// user_agent, screen_width, etc. - see branch_view._getPageviewRequestData),
-			// so a setRequestMetaData() key that happens to match one of those names
-			// will silently overwrite it (or vice versa, depending on merge order).
 			d['metadata'] = utils.merge(d['metadata'] || {}, d['branch_requestMetadata']);
 			delete d['branch_requestMetadata'];
 		}

--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -1992,7 +1992,8 @@ Branch.prototype['setDMAParamsForEEA'] = wrap(callback_params.CALLBACK_ERR, func
  * @param {String} key - Request metadata key
  * @param {String} value - Request metadata value
  * Sets request metadata that gets passed along with all the API calls, including
- * v1/pageview and v1/dismiss (nested under metadata.branch_requestMetadata for those two).
+ * v1/pageview and v1/dismiss (merged directly into that request's metadata field,
+ * same as every other endpoint).
  */
 Branch.prototype['setRequestMetaData'] = function(key, value) {
 	try {

--- a/test/6_branch_new.js
+++ b/test/6_branch_new.js
@@ -73,7 +73,7 @@ describe('Branch - new', function() {
 			method: utils.httpMethod.POST
 		};
 
-		it('should nest branch_requestMetadata inside metadata for v1/pageview instead of dropping it', function() {
+		it('should merge branch_requestMetadata directly into metadata for v1/pageview instead of dropping it', function() {
 			var server = new Server();
 			var result = server.getUrl(pageviewResource, {
 				branch_key: window.branch_sample_key,
@@ -84,12 +84,13 @@ describe('Branch - new', function() {
 			assert.strictEqual(typeof result.error, 'undefined');
 			var metadataMatch = decodeURIComponent(result.data).match(/metadata=(.+?)(&|$)/);
 			var metadata = safejson.parse(metadataMatch[1]);
-			assert.deepEqual(metadata.branch_requestMetadata, { '$marketing_cloud_visitor_id': '12345' });
+			assert.strictEqual(metadata['$marketing_cloud_visitor_id'], '12345');
 			assert.strictEqual(metadata.url, 'http://example.com');
 			assert.strictEqual(result.data.indexOf('branch_requestMetadata='), -1, 'not sent as a top-level field');
+			assert.strictEqual(typeof metadata.branch_requestMetadata, 'undefined', 'not nested under its own key');
 		});
 
-		it('should nest branch_requestMetadata inside metadata for v1/dismiss instead of dropping it', function() {
+		it('should merge branch_requestMetadata directly into metadata for v1/dismiss instead of dropping it', function() {
 			var server = new Server();
 			var result = server.getUrl(dismissResource, {
 				branch_key: window.branch_sample_key,
@@ -100,7 +101,7 @@ describe('Branch - new', function() {
 			assert.strictEqual(typeof result.error, 'undefined');
 			var metadataMatch = decodeURIComponent(result.data).match(/metadata=(.+?)(&|$)/);
 			var metadata = safejson.parse(metadataMatch[1]);
-			assert.deepEqual(metadata.branch_requestMetadata, { '$marketing_cloud_visitor_id': '12345' });
+			assert.strictEqual(metadata['$marketing_cloud_visitor_id'], '12345');
 		});
 	});
 	describe('setDMAParamsForEEA', function() {


### PR DESCRIPTION
## Description
merge it directly into the metadata field, matching how every other endpoint sends insted of nested. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit test
- [ ] Integration test

## JS Budget Check

Please mention the size in kb before and after this PR

| Files            | Before      | After       | 
| -----------      | ----------- | ----------- |
| dist/build.js.   |             |             |
| dist/build.min.js|             |             |

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Mentions: 
List the person or team responsible for reviewing proposed changes.

cc @BranchMetrics/saas-sdk-devs for visibility.
